### PR TITLE
Don't run tests for Go 1.9/tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.7.x
-  - tip
+  - 1.8
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.6
   - 1.7.x
-  - 1.8
 
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Don't run tests forGo. 1.9/tip for now.

Please see:
golang/net@b4690f4