### PR TITLE
Remove StateDegraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ and developers. It's a just-working proof-of-concept.
 - [ ] No false positives - the system should never cry wolf.
 - [x] Easy encryption - should support Let’s Encrypt out of the box.
 - [x] Future-proof - Everything must support IPv6 out of the box.
+- [x] Binary outcome - either a human should do something or not.
 
 #### Alert integrations
 

--- a/eval/Evaluation.go
+++ b/eval/Evaluation.go
@@ -48,5 +48,5 @@ func LatestEvaluation(db database.Reader, result *checks.CheckResult) (*Evaluati
 		return nil, database.ErrNotFound
 	}
 
-	return &results[0], database.ErrNotFound
+	return &results[0], nil
 }

--- a/eval/Evaluator.go
+++ b/eval/Evaluator.go
@@ -79,7 +79,7 @@ func (e *Evaluator) evaluate(checkResult *checks.CheckResult) (*Evaluation, erro
 		eval = nextEval
 	}
 
-	logger.Debug("eval", "%s: %s (%s) %v", eval.CheckHostID, eval.History.Reduce().ColorString(), eval.End.Sub(eval.Start).String(), eval.History)
+	logger.Debug("eval", "%s: %s (%s) %s", eval.CheckHostID, eval.History.Reduce().ColorString(), eval.End.Sub(eval.Start).String(), eval.History.ColorString())
 
 	return eval, e.db.Save(eval)
 }

--- a/eval/Evaluator.go
+++ b/eval/Evaluator.go
@@ -43,7 +43,7 @@ func statesFromHistory(history []checks.CheckResult) States {
 }
 
 // evaluate will FIXME
-func (e *Evaluator) evaluate(checkResult *checks.CheckResult) (*Evaluation, error) {
+func (e *Evaluator) Evaluate(checkResult *checks.CheckResult) (*Evaluation, error) {
 	clock := time.Now()
 
 	// Get latest evaluation.
@@ -99,6 +99,6 @@ func (e *Evaluator) PostApply(leader bool, command database.Command, data interf
 
 	switch data.(type) {
 	case *checks.CheckResult:
-		e.evaluate(data.(*checks.CheckResult))
+		e.Evaluate(data.(*checks.CheckResult))
 	}
 }

--- a/eval/Evaluator_test.go
+++ b/eval/Evaluator_test.go
@@ -63,7 +63,7 @@ func TestEvaluatorEvaluate1Basics(t *testing.T) {
 		Node:        "justone",
 	}
 
-	_, err := e.evaluate(result)
+	_, err := e.Evaluate(result)
 	if err != nil {
 		t.Fatalf("evaluate() failed: %s", err.Error())
 	}
@@ -81,7 +81,7 @@ func TestEvaluatorEvaluate1Basics(t *testing.T) {
 	// Move one minute into the future.
 	result.TimeStamp = result.TimeStamp.Add(time.Minute)
 
-	_, err = e.evaluate(result)
+	_, err = e.Evaluate(result)
 	if err != nil {
 		t.Fatalf("evaluate() failed: %s", err.Error())
 	}
@@ -144,7 +144,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 			t.Fatalf("Save() failed: %s", err.Error())
 		}
 
-		e, _ := e.evaluate(&c.in)
+		e, _ := e.Evaluate(&c.in)
 		if e.State != c.state {
 			t.Fatalf("evaluate() [%d] concluded wrong state. Got %s, expected %s", i, e.State.ColorString(), c.state.ColorString())
 		}

--- a/eval/Evaluator_test.go
+++ b/eval/Evaluator_test.go
@@ -16,10 +16,6 @@ type (
 	mockAgent struct {
 		ReturnError bool `json:"return_error"`
 	}
-
-	peerStore struct {
-		peers []string
-	}
 )
 
 var (
@@ -46,20 +42,7 @@ func init() {
 	check.ID = "test"
 }
 
-func (p *peerStore) SetPeers(peers []string) error {
-	p.peers = peers
-
-	return nil
-}
-
-func (p *peerStore) Peers() ([]string, error) {
-	return p.peers, nil
-}
-
-func newE(t *testing.T, nodes []string) (*boltdb.TestStore, *Evaluator) {
-	peers := &peerStore{}
-	peers.SetPeers(nodes)
-
+func newE(t *testing.T) (*boltdb.TestStore, *Evaluator) {
 	db := boltdb.NewTestStore()
 
 	e := NewEvaluator(db)
@@ -71,7 +54,7 @@ func newE(t *testing.T, nodes []string) (*boltdb.TestStore, *Evaluator) {
 }
 
 func TestEvaluatorEvaluate1Basics(t *testing.T) {
-	db, e := newE(t, []string{"justone"})
+	db, e := newE(t)
 	defer db.Close()
 
 	result := &checks.CheckResult{
@@ -114,7 +97,7 @@ func TestEvaluatorEvaluate1Basics(t *testing.T) {
 }
 
 func TestEvaluatorEvaluate(t *testing.T) {
-	db, e := newE(t, []string{"justone"})
+	db, e := newE(t)
 	defer db.Close()
 
 	cases := []struct {
@@ -169,7 +152,7 @@ func TestEvaluatorEvaluate(t *testing.T) {
 }
 
 func TestEvaluatorPostApply(t *testing.T) {
-	db, e := newE(t, []string{"justone"})
+	db, e := newE(t)
 	defer db.Close()
 
 	result := &checks.CheckResult{

--- a/eval/Evaluator_test.go
+++ b/eval/Evaluator_test.go
@@ -113,7 +113,7 @@ func TestEvaluatorEvaluate1Basics(t *testing.T) {
 	}
 }
 
-func TestEvaluatorEvaluate1(t *testing.T) {
+func TestEvaluatorEvaluate(t *testing.T) {
 	db, e := newE(t, []string{"justone"})
 	defer db.Close()
 
@@ -128,16 +128,29 @@ func TestEvaluatorEvaluate1(t *testing.T) {
 		{checks.CheckResult{}, StateUp},
 		{checks.CheckResult{}, StateUp},
 		{checks.CheckResult{}, StateUp},
-		{checks.CheckResult{Error: "error"}, StateDegraded},
-		{checks.CheckResult{Error: "error"}, StateDegraded},
-		{checks.CheckResult{Error: "error"}, StateDegraded},
-		{checks.CheckResult{}, StateDegraded},
-		{checks.CheckResult{Error: "error"}, StateDegraded},
-		{checks.CheckResult{}, StateDegraded},
-		{checks.CheckResult{}, StateDegraded},
-		{checks.CheckResult{}, StateDegraded},
-		{checks.CheckResult{}, StateDegraded},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateDown},
+		{checks.CheckResult{}, StateDown},
+		{checks.CheckResult{Error: "error"}, StateDown},
+		{checks.CheckResult{}, StateDown},
 		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateUp},
+		{checks.CheckResult{Error: "error"}, StateDown},
+		{checks.CheckResult{Error: "error"}, StateDown},
+		{checks.CheckResult{Error: "error"}, StateDown},
+		{checks.CheckResult{}, StateDown},
+		{checks.CheckResult{}, StateDown},
+		{checks.CheckResult{Error: "error"}, StateDown},
 		{checks.CheckResult{}, StateUp},
 		{checks.CheckResult{}, StateUp},
 	}

--- a/eval/State.go
+++ b/eval/State.go
@@ -16,9 +16,6 @@ const (
 	// StateUp is a Check that is OK or "green".
 	StateUp State = iota
 
-	// StateDegraded is a Check that is not completely ok or "yellow".
-	StateDegraded State = iota
-
 	// StateDown is a Check with failed conditions.
 	StateDown State = iota
 
@@ -28,40 +25,35 @@ const (
 )
 
 const (
-	red    = "\033[31m"
-	yellow = "\033[33m"
-	green  = "\033[32m"
-	blue   = "\033[34m"
-	reset  = "\033[0m"
+	red   = "\033[31m"
+	green = "\033[32m"
+	blue  = "\033[34m"
+	reset = "\033[0m"
 )
 
 var (
 	stateToJSON = map[State]string{
-		StateUnknown:  `""`,
-		StateUp:       `"up"`,
-		StateDegraded: `"degraded"`,
-		StateDown:     `"down"`,
+		StateUnknown: `""`,
+		StateUp:      `"up"`,
+		StateDown:    `"down"`,
 	}
 
 	jsonToState = map[string]State{
-		`""`:         StateUnknown,
-		`"up"`:       StateUp,
-		`"degraded"`: StateDegraded,
-		`"down"`:     StateDown,
+		`""`:     StateUnknown,
+		`"up"`:   StateUp,
+		`"down"`: StateDown,
 	}
 
 	stateToHuman = map[State]string{
-		StateUnknown:  "Unknown",
-		StateUp:       "Up",
-		StateDegraded: "Degraded",
-		StateDown:     "Down",
+		StateUnknown: "Unknown",
+		StateUp:      "Up",
+		StateDown:    "Down",
 	}
 
 	stateToColor = map[State]string{
-		StateUnknown:  blue,
-		StateUp:       green,
-		StateDegraded: yellow,
-		StateDown:     red,
+		StateUnknown: blue,
+		StateUp:      green,
+		StateDown:    red,
 	}
 )
 

--- a/eval/State_test.go
+++ b/eval/State_test.go
@@ -12,7 +12,6 @@ func TestValid(t *testing.T) {
 	}{
 		{StateUnknown, true},
 		{StateUp, true},
-		{StateDegraded, true},
 		{StateDown, true},
 		{State(39), false},
 	}
@@ -33,7 +32,6 @@ func TestMarshalJSON(t *testing.T) {
 	}{
 		{StateUnknown, `""`},
 		{StateUp, `"up"`},
-		{StateDegraded, `"degraded"`},
 		{StateDown, `"down"`},
 		{State(39), `""`},
 	}
@@ -57,7 +55,6 @@ func TestColorString(t *testing.T) {
 	}{
 		{StateUnknown, blue + "Unknown" + reset},
 		{StateUp, green + "Up" + reset},
-		{StateDegraded, yellow + "Degraded" + reset},
 		{StateDown, red + "Down" + reset},
 		{State(39), "" + reset},
 	}
@@ -75,8 +72,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	j := `{
         "s1": "up",
         "s2": "down",
-        "s3": "",
-        "s4": "degraded"
+        "s3": ""
         }`
 
 	out := make(map[string]State)
@@ -86,7 +82,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Fatalf("JSON unmarshal failed: %s", err.Error())
 	}
 
-	if out["s1"] != StateUp || out["s2"] != StateDown || out["s3"] != StateUnknown || out["s4"] != StateDegraded {
+	if out["s1"] != StateUp || out["s2"] != StateDown || out["s3"] != StateUnknown {
 		t.Fatalf("Failed to decode JSON properly")
 	}
 

--- a/eval/States.go
+++ b/eval/States.go
@@ -50,10 +50,11 @@ func (s *States) Last(n int) *States {
 
 // Reduce reduces the slice of states to a single state according to a very
 // simple algorithm:
-// If there's noe states stores, the result is StateUnknown.
-// If any of the states are StateUnknown, return StateUnknown.
-// If all states are the same, the result is that state.
-// If the contained states are mixed, the result are StateDegraded.
+// 1) If there's no states stored, return StateUnknown.
+// 2) If any state is StateUnknown, return StateUnknown.
+// 3) If no state is StateUnknown, and there is a majority that majority is
+//    returned.
+// 4) If none of 1-3 is satisfied, StateUnknown will we returned.
 func (s *States) Reduce() State {
 	l := len(*s)
 
@@ -68,16 +69,12 @@ func (s *States) Reduce() State {
 	}
 
 	for state, count := range hist {
-		if state >= stateMax {
-			return StateUnknown
-		}
-
-		if count == l {
+		if count > l/2 {
 			return state
 		}
 	}
 
-	return StateDegraded
+	return StateUnknown
 }
 
 // ColorString will return a nicely colored array.

--- a/eval/States_test.go
+++ b/eval/States_test.go
@@ -71,7 +71,6 @@ func TestLast(t *testing.T) {
 	}{
 		{States{}, 0, States{}},
 		{States{StateDown}, 0, States{}},
-		{States{StateDown, StateDegraded}, 0, States{}},
 		{States{StateDown, StateUp}, 1, States{StateDown}},
 		{States{StateDown, StateUp}, 2, States{StateDown, StateUp}},
 		{States{StateDown, StateUp}, 3, States{StateDown, StateUp}},
@@ -87,7 +86,7 @@ func TestLast(t *testing.T) {
 	}
 }
 
-func TestEvaluate(t *testing.T) {
+func TestReduce(t *testing.T) {
 	cases := []struct {
 		input    States
 		expected State
@@ -95,14 +94,15 @@ func TestEvaluate(t *testing.T) {
 		{States{}, StateUnknown},
 		{States{StateDown}, StateDown},
 		{States{StateUp}, StateUp},
+		{States{StateUp, StateDown}, StateUnknown},
 		{States{StateUnknown}, StateUnknown},
-		{States{StateDegraded}, StateDegraded},
-		{States{StateUp, StateDegraded}, StateDegraded},
+		{States{StateUnknown, StateUp}, StateUnknown},
+		{States{StateUnknown, StateUp, StateDown, StateUp, StateUp}, StateUnknown},
 		{States{StateUp, StateUp}, StateUp},
-		{States{StateUp, StateUp, StateUp, StateDown}, StateDegraded},
-		{States{StateUnknown, StateDegraded, StateUp}, StateUnknown},
-		{States{State(34)}, StateUnknown},
-		{States{StateUp, StateUp, StateUp, State(35)}, StateUnknown},
+		{States{StateUp, StateUp, StateUp, StateDown}, StateUp},
+		{States{StateUnknown, StateDown, StateUp}, StateUnknown},
+		{States{State(34)}, State(34)},
+		{States{StateUp, StateUp, StateUp, State(35)}, StateUp},
 	}
 
 	for _, dat := range cases {
@@ -123,11 +123,10 @@ func TestStatesJSON(t *testing.T) {
 		{States{StateDown}, []byte(`["down"]`)},
 		{States{StateUp}, []byte(`["up"]`)},
 		{States{StateUnknown}, []byte(`[""]`)},
-		{States{StateDegraded}, []byte(`["degraded"]`)},
-		{States{StateUp, StateDegraded}, []byte(`["up","degraded"]`)},
+		{States{StateUp, StateDown}, []byte(`["up","down"]`)},
 		{States{StateUp, StateUp}, []byte(`["up","up"]`)},
 		{States{StateUp, StateUp, StateUp, StateDown}, []byte(`["up","up","up","down"]`)},
-		{States{StateUnknown, StateDegraded, StateUp}, []byte(`["","degraded","up"]`)},
+		{States{StateUnknown, StateDown, StateUp}, []byte(`["","down","up"]`)},
 	}
 
 	for _, dat := range cases {
@@ -165,11 +164,8 @@ func TestStatesColorString(t *testing.T) {
 		{States{StateDown}, 21},
 		{States{StateUp}, 19},
 		{States{StateUnknown}, 24},
-		{States{StateDegraded}, 25},
-		{States{StateUp, StateDegraded}, 37},
 		{States{StateUp, StateUp}, 31},
 		{States{StateUp, StateUp, StateUp, StateDown}, 57},
-		{States{StateUnknown, StateDegraded, StateUp}, 54},
 	}
 
 	for _, dat := range cases {

--- a/notify/Contact.go
+++ b/notify/Contact.go
@@ -39,7 +39,7 @@ func (c *Contact) Notify(text string) error {
 		return fmt.Errorf("Unknown notifier: %s", c.Notifier)
 	}
 
-	err := json.Unmarshal(c.Arguments, &notifier)
+	err := json.Unmarshal(c.Arguments, notifier)
 	if err != nil {
 		return err
 	}

--- a/notify/Notifier.go
+++ b/notify/Notifier.go
@@ -51,20 +51,12 @@ func (n *Notifier) PostApply(leader bool, command database.Command, data interfa
 
 func (n *Notifier) gotEvaluation(e *eval.Evaluation) error {
 	var check checks.Check
-	// FIXME: Does this EVER find anything?
 	err := n.db.One("ID", e.CheckID, &check)
 	if err != nil {
 		return err
 	}
 
 	state := e.History.Last(3).Reduce()
-
-	// If the state is unknown do nothing. It means that the check has not been
-	// live long enough to conclude anything.
-	if state == eval.StateUnknown {
-		logger.Debug("notify", "[%s] Ignoring %s %s", e.CheckHostID, state.String(), e.History.ColorString())
-		return nil
-	}
 
 	// For how long have we had this state?
 	duration := e.End.Sub(e.Start)

--- a/notify/Notifier.go
+++ b/notify/Notifier.go
@@ -51,27 +51,34 @@ func (n *Notifier) PostApply(leader bool, command database.Command, data interfa
 
 func (n *Notifier) gotEvaluation(e *eval.Evaluation) error {
 	var check checks.Check
-	err := n.db.One("ID", e.CheckHostID, &check)
+	// FIXME: Does this EVER find anything?
+	err := n.db.One("ID", e.CheckID, &check)
 	if err != nil {
 		return err
 	}
 
 	state := e.History.Last(3).Reduce()
 
+	// If the state is unknown do nothing. It means that the check has not been
+	// live long enough to conclude anything.
 	if state == eval.StateUnknown {
 		logger.Debug("notify", "[%s] Ignoring %s %s", e.CheckHostID, state.String(), e.History.ColorString())
 		return nil
 	}
 
+	// For how long have we had this state?
 	duration := e.End.Sub(e.Start)
 
+	// Retrieve the last known state of the check. If the last state is
+	// unknown, StateUnknown will be used.
 	stateCacheLock.RLock()
 	lastState := stateCache[e.CheckHostID]
 	stateCacheLock.RUnlock()
 
+	// If nothing changed since last evaluation, we can safely abort since
+	// there's nothing to notify about.
 	if state == lastState {
 		logger.Debug("notify", "[%s] Ignoring unchanged state (Last: %s, Current: %s, Duration: %s) %s", e.CheckHostID, lastState, state, duration.String(), e.History.ColorString())
-		// Nothing changed. Abort.
 		return nil
 	}
 
@@ -79,18 +86,15 @@ func (n *Notifier) gotEvaluation(e *eval.Evaluation) error {
 	stateCache[e.CheckHostID] = state
 	stateCacheLock.Unlock()
 
+	// If we arrive here we know that state has changed since last evaluation.
+	// If we changed from StateUnknown, we ignore this state change because it
+	// is caused by a check "coming online".
 	if lastState == eval.StateUnknown {
 		logger.Info("notify", "[%s] Ignoring %s when previous state is %s %v", e.CheckHostID, state, lastState, e.History.ColorString())
-		// Last state was unknown. Maybe we just started. Don't notify.
 		return nil
 	}
 
 	logger.Info("notify", "%s is %s %s", e.CheckHostID, state, e.History.ColorString())
-
-	if len(check.ContactGroups) == 0 {
-		logger.Info("notify", "[%s] No-one to nofity, aborting", e.CheckHostID)
-		return nil
-	}
 
 	text := fmt.Sprintf("%s is %s", e.CheckHostID, state.String())
 

--- a/notify/Notifier.go
+++ b/notify/Notifier.go
@@ -85,11 +85,6 @@ func (n *Notifier) gotEvaluation(e *eval.Evaluation) error {
 		return nil
 	}
 
-	if duration < check.Interval*2 && state == eval.StateDegraded {
-		logger.Info("notify", "[%s] Ignoring %s for less than two cycles when degraded %s", e.CheckHostID, state, e.History.ColorString())
-		return nil
-	}
-
 	logger.Info("notify", "%s is %s %s", e.CheckHostID, state, e.History.ColorString())
 
 	if len(check.ContactGroups) == 0 {

--- a/notify/Notifier_test.go
+++ b/notify/Notifier_test.go
@@ -1,7 +1,139 @@
 package notify
 
 import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gansoi/gansoi/boltdb"
+	"github.com/gansoi/gansoi/checks"
 	"github.com/gansoi/gansoi/database"
+	"github.com/gansoi/gansoi/eval"
+	"github.com/gansoi/gansoi/plugins"
 )
+
+type (
+	mock struct {
+		Err bool `json:"err"`
+	}
+)
+
+func init() {
+	plugins.RegisterAgent("mock", mock{})
+}
+
+func (m *mock) Check(result plugins.AgentResult) error {
+	if m.Err {
+		return errors.New("error")
+	}
+
+	return nil
+}
+
+func TestGotEvaluation(t *testing.T) {
+	db := boltdb.NewTestStore()
+
+	contact := &Contact{
+		Name:     "testcontact",
+		Notifier: "testnotifier",
+	}
+	err := db.Save(contact)
+	if err != nil {
+		t.Fatalf("Save() failed: %s", err.Error())
+	}
+
+	group := &ContactGroup{
+		Name:    "testgroup",
+		Members: []string{contact.GetID()},
+	}
+	err = db.Save(group)
+	if err != nil {
+		t.Fatalf("Save() failed: %s", err.Error())
+	}
+
+	check := &checks.Check{
+		Name:          "test",
+		AgentID:       "mock",
+		ContactGroups: []string{group.GetID(), "nonexisting"},
+	}
+	err = db.Save(check)
+	if err != nil {
+		t.Fatalf("Save() failed: %s", err.Error())
+	}
+
+	e := eval.NewEvaluator(db)
+	n, _ := NewNotifier(db)
+
+	timeline := []struct {
+		err bool
+	}{
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{true},
+		{false},
+		{false},
+		{false},
+		{false},
+		{false},
+		{true},
+		{false},
+		{false},
+		{true},
+		{false},
+		{false},
+	}
+
+	for _, c := range timeline {
+		if c.err {
+			check.Arguments = json.RawMessage(`{"err": true}`)
+		} else {
+			check.Arguments = json.RawMessage(`{}`)
+		}
+
+		result := checks.RunCheck(nil, check)
+		result.CheckHostID = checks.CheckHostID(check.GetID(), "")
+		result.CheckID = check.GetID()
+
+		err = db.Save(result)
+		if err != nil {
+			t.Fatalf("Save() failed: %s", err.Error())
+		}
+
+		e.PostApply(true, database.CommandSave, result)
+		evaluation, err := eval.LatestEvaluation(db, result)
+		if err != nil {
+			t.Fatalf("LatestEvaluation() failed: %s", err.Error())
+		}
+
+		err = n.gotEvaluation(evaluation)
+		if err != nil {
+			t.Fatalf("gotEvaluation() failed: %s", err.Error())
+		}
+	}
+}
 
 var _ database.Listener = (*Notifier)(nil)

--- a/notify/Notifier_test.go
+++ b/notify/Notifier_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gansoi/gansoi/boltdb"
 	"github.com/gansoi/gansoi/checks"
@@ -143,14 +142,11 @@ func TestGotEvaluation(t *testing.T) {
 			t.Fatalf("Save() failed: %s", err.Error())
 		}
 
-		time.Sleep(time.Millisecond * 15)
-		e.PostApply(true, database.CommandSave, result)
-		evaluation, err := eval.LatestEvaluation(db, result)
+		evaluation, err := e.Evaluate(result)
 		if err != nil {
-			t.Fatalf("LatestEvaluation() failed: %s", err.Error())
+			t.Fatalf("Evaluate() failed: %s", err.Error())
 		}
 
-		time.Sleep(time.Millisecond * 15)
 		n.PostApply(true, database.CommandSave, evaluation)
 		//		err = n.gotEvaluation(evaluation)
 		if err != nil {


### PR DESCRIPTION
`StateDegraded` is not very useful. Gansoi should be able to tell if 'a human is needed' or 'a human is not needed' - `StateDegraded` fell between these two outcomes requiring a human to decide if 'a human is needed' or not.

This PR removes that state.