### PR TITLE
Add support for SSH banner

### DIFF
--- a/plugins/agents/ssh/SSH.go
+++ b/plugins/agents/ssh/SSH.go
@@ -40,6 +40,12 @@ func (s *SSH) Check(result plugins.AgentResult) error {
 		return nil
 	}
 
+	// We also save the banner if available.
+	conf.BannerCallback = func(message string) error {
+		result.AddValue("Banner", message)
+		return nil
+	}
+
 	start := time.Now()
 	conn, err := ssh.Dial("tcp", defaultPort(s.Address), &conf)
 

--- a/plugins/agents/ssh/SSH_test.go
+++ b/plugins/agents/ssh/SSH_test.go
@@ -124,12 +124,51 @@ func TestCheck(t *testing.T) {
 	}
 
 	config.NoClientAuth = true
+
 	acceptOneSSH(listener, config)
 
 	//	config.PasswordCallback = nil
 	err = a.Check(result)
 	if err != nil {
 		t.Fatalf("Check() failed: %s", err.Error())
+	}
+}
+
+func TestBanner(t *testing.T) {
+	config := &ssh.ServerConfig{
+		NoClientAuth: false,
+		BannerCallback: func(_ ssh.ConnMetadata) string {
+			return "this is a banner"
+		},
+	}
+	config.SetDefaults()
+	config.PasswordCallback = func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+		return nil, errors.New("Password rejected")
+	}
+
+	key, _ := ssh.ParsePrivateKey(hostKey)
+	config.AddHostKey(key)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() failed: %s", err.Error())
+	}
+	defer listener.Close()
+
+	acceptOneSSH(listener, config)
+
+	a := SSH{
+		Address: listener.Addr().String(),
+	}
+
+	result := plugins.NewAgentResult()
+	err = a.Check(result)
+	if err != nil {
+		t.Fatalf("Check() failed: %s", err.Error())
+	}
+
+	if result["Banner"] != "this is a banner" {
+		t.Fatalf("Banner looks wrong, got %s", result["Banner"])
 	}
 }
 


### PR DESCRIPTION
This PR will add support for saving the SSH banner to the SSH agent.

Please note that the SSH agent is broken for *any* server that displays a banner until https://github.com/golang/go/issues/22359 is resolved.