### PR TITLE
Save the join token at new core members

### DIFF
--- a/cluster/Core.go
+++ b/cluster/Core.go
@@ -221,6 +221,7 @@ func (c *Core) Join(address string, hash string, token string, bindPrivate strin
 	logger.Info("join", "Local core initialized")
 
 	c.info.ClusterToken = token
+	c.info.Save()
 
 	// Request to join cluster.
 	logger.Info("join", "Requesting raft join")


### PR DESCRIPTION
Only the original leader will be able to add new nodes. This PR fixes that.